### PR TITLE
Append unique string to files with duplicate filenames

### DIFF
--- a/PatreonDownloader.App/Models/CommandLineOptions.cs
+++ b/PatreonDownloader.App/Models/CommandLineOptions.cs
@@ -25,6 +25,9 @@ namespace PatreonDownloader.App.Models
         [Option("no-headless", Required = false, HelpText = "Show internal browser window (disable headless mode)", Default = false)]
         public bool NoHeadless { get; set; }
 
+        [Option("overwrite-files", Required = false, HelpText = "Overwrite already existing files (recommended if creator might have files multiple files with the same filename or makes changes to already existing posts)", Default = false)]
+        public bool OverwriteFiles { get; set; }
+
         /*[Option("cookie-retriever", Required = false, HelpText = "Cookie retriever plugin to use", Default = "PuppeteerCookieRetriever")]
         public string CookieRetriever { get; set; }*/
     }

--- a/PatreonDownloader.App/Program.cs
+++ b/PatreonDownloader.App/Program.cs
@@ -45,7 +45,8 @@ namespace PatreonDownloader.App
                     SaveDescriptions = options.SaveDescriptions,
                     SaveEmbeds = options.SaveEmbeds,
                     SaveJson = options.SaveJson,
-                    DownloadDirectory = options.DownloadDirectory
+                    DownloadDirectory = options.DownloadDirectory,
+                    OverwriteFiles = options.OverwriteFiles
                 };
                 NLogManager.ReconfigureNLog(options.Verbose);
             });

--- a/PatreonDownloader.Common/Interfaces/IDownloader.cs
+++ b/PatreonDownloader.Common/Interfaces/IDownloader.cs
@@ -5,6 +5,11 @@ namespace PatreonDownloader.Common.Interfaces
 {
     public interface IDownloader
     {
+        /// <summary>
+        /// Initialization function, called by IPluginManager's BeforeStart() function
+        /// </summary>
+        /// <returns></returns>
+        Task BeforeStart();
         Task<bool> IsSupportedUrl(string url);
         Task Download(CrawledUrl crawledUrl, string downloadDirectory);
     }

--- a/PatreonDownloader.Engine/IPluginManager.cs
+++ b/PatreonDownloader.Engine/IPluginManager.cs
@@ -8,6 +8,11 @@ namespace PatreonDownloader.Engine
 {
     internal interface IPluginManager
     {
+        /// <summary>
+        /// Initialization function, called on every PatreonDownloader.Download call
+        /// </summary>
+        /// <returns></returns>
+        Task BeforeStart();
         Task<IDownloader> GetDownloader(string url);
     }
 }

--- a/PatreonDownloader.Engine/PatreonDownloader.cs
+++ b/PatreonDownloader.Engine/PatreonDownloader.cs
@@ -115,6 +115,12 @@ namespace PatreonDownloader.Engine
                         Initialize();
                     }
 
+                    //Call initialization code in all plugins
+                    await _pluginManager.BeforeStart();
+
+                    //Call initialization code in direct downloader
+                    await _directDownloader.BeforeStart();
+
                     try
                     {
                         await _cookieValidator.ValidateCookies(_cookieContainer);

--- a/PatreonDownloader.Engine/PatreonDownloader.cs
+++ b/PatreonDownloader.Engine/PatreonDownloader.cs
@@ -112,7 +112,7 @@ namespace PatreonDownloader.Engine
                     if (!_isInitialized)
                     {
                         _logger.Debug("Initiaization required");
-                        Initialize();
+                        Initialize(settings);
                     }
 
                     //Call initialization code in all plugins
@@ -192,7 +192,7 @@ namespace PatreonDownloader.Engine
             }
         }
 
-        private void Initialize()
+        private void Initialize(PatreonDownloaderSettings settings)
         {
             if (_isInitialized)
                 return;
@@ -206,7 +206,7 @@ namespace PatreonDownloader.Engine
             _puppeteerEngine = new PuppeteerEngine.PuppeteerEngine(_headlessBrowser);
 
             _logger.Debug("Initializing file downloader");
-            _webDownloader = new WebDownloader(_cookieContainer, _puppeteerEngine);
+            _webDownloader = new WebDownloader(_cookieContainer, _puppeteerEngine, settings.OverwriteFiles);
 
             _logger.Debug("Initializing cookie validator");
             _cookieValidator = new CookieValidator(_webDownloader);

--- a/PatreonDownloader.Engine/PatreonDownloaderSettings.cs
+++ b/PatreonDownloader.Engine/PatreonDownloaderSettings.cs
@@ -12,6 +12,7 @@ namespace PatreonDownloader.Engine
         private bool _saveJson;
         private bool _saveAvatarAndCover;
         private string _downloadDirectory;
+        private bool _overwriteFiles;
 
         /// <summary>
         /// Any attempt to set properties will result in exception if this set to true
@@ -51,6 +52,15 @@ namespace PatreonDownloader.Engine
             set => ConsumableSetter.Set(Consumed, ref _downloadDirectory, value);
         }
 
+        /// <summary>
+        /// Overwrite already existing files
+        /// </summary>
+        public bool OverwriteFiles
+        {
+            get => _overwriteFiles;
+            set => ConsumableSetter.Set(Consumed, ref _overwriteFiles, value);
+        }
+
         public PatreonDownloaderSettings()
         {
             _saveDescriptions = true;
@@ -58,11 +68,12 @@ namespace PatreonDownloader.Engine
             _saveJson = true;
             _saveAvatarAndCover = true;
             _downloadDirectory = null;
+            _overwriteFiles = false;
         }
 
         public override string ToString()
         {
-            return $"SaveDescriptions={_saveDescriptions},SaveEmbeds={_saveEmbeds},SaveJson={_saveJson},SaveAvatarAndCover={_saveAvatarAndCover},DownloadDirectory={_downloadDirectory}";
+            return $"SaveDescriptions={_saveDescriptions},SaveEmbeds={_saveEmbeds},SaveJson={_saveJson},SaveAvatarAndCover={_saveAvatarAndCover},DownloadDirectory={_downloadDirectory},OverwriteFiles={_overwriteFiles}";
         }
     }
 }

--- a/PatreonDownloader.Engine/PluginManager.cs
+++ b/PatreonDownloader.Engine/PluginManager.cs
@@ -95,5 +95,13 @@ namespace PatreonDownloader.Engine
 
             return null;
         }
+
+        public async Task BeforeStart()
+        {
+            foreach (IDownloader downloader in _downloaders)
+            {
+                await downloader.BeforeStart();
+            }
+        }
     }
 }

--- a/PatreonDownloader.Engine/Stages/Downloading/DirectDownloader.cs
+++ b/PatreonDownloader.Engine/Stages/Downloading/DirectDownloader.cs
@@ -25,15 +25,21 @@ namespace PatreonDownloader.Engine.Stages.Downloading
         private readonly Logger _logger = LogManager.GetCurrentClassLogger();
         private Dictionary<string, int> _fileCountDict; //file counter for duplicate check
 
-        private readonly Regex _fileIdRegex; //Regex used to retrieve file id from its url
+        private static readonly Regex _fileIdRegex; //Regex used to retrieve file id from its url
+
+        static DirectDownloader()
+        {
+            _fileIdRegex =
+                new Regex(
+                    "https:\\/\\/(.+)\\.patreonusercontent\\.com\\/(.+)\\/(.+)\\/patreon-media\\/p\\/post\\/([0-9]+)\\/([a-z0-9]+)",
+                    RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        }
 
         public DirectDownloader(IWebDownloader webDownloader, IRemoteFilenameRetriever remoteFilenameRetriever)
         {
             _webDownloader = webDownloader ?? throw new ArgumentNullException(nameof(webDownloader));
             _remoteFilenameRetriever = remoteFilenameRetriever ??
                                        throw new ArgumentNullException(nameof(remoteFilenameRetriever));
-
-            _fileIdRegex = new Regex("https:\\/\\/(.+)\\.patreonusercontent\\.com\\/(.+)\\/(.+)\\/patreon-media\\/p\\/post\\/([0-9]+)\\/([a-z0-9]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
         }
 
         public async Task<bool> IsSupportedUrl(string url)

--- a/PatreonDownloader.Engine/Stages/Downloading/DirectDownloader.cs
+++ b/PatreonDownloader.Engine/Stages/Downloading/DirectDownloader.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Net.Http;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using NLog;
 using PatreonDownloader.Common.Interfaces;
@@ -24,11 +25,15 @@ namespace PatreonDownloader.Engine.Stages.Downloading
         private readonly Logger _logger = LogManager.GetCurrentClassLogger();
         private Dictionary<string, int> _fileCountDict; //file counter for duplicate check
 
+        private readonly Regex _fileIdRegex; //Regex used to retrieve file id from its url
+
         public DirectDownloader(IWebDownloader webDownloader, IRemoteFilenameRetriever remoteFilenameRetriever)
         {
             _webDownloader = webDownloader ?? throw new ArgumentNullException(nameof(webDownloader));
             _remoteFilenameRetriever = remoteFilenameRetriever ??
                                        throw new ArgumentNullException(nameof(remoteFilenameRetriever));
+
+            _fileIdRegex = new Regex("https:\\/\\/(.+)\\.patreonusercontent\\.com\\/(.+)\\/(.+)\\/patreon-media\\/p\\/post\\/([0-9]+)\\/([a-z0-9]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
         }
 
         public async Task<bool> IsSupportedUrl(string url)
@@ -135,8 +140,23 @@ namespace PatreonDownloader.Engine.Stages.Downloading
 
             if (_fileCountDict[key] > 1)
             {
-                _logger.Warn($"Found more than a single file with the name {filename} in post {crawledUrl.PostId}, a number will be appended to its name.");
-                filename = $"{Path.GetFileNameWithoutExtension(filename)}_{_fileCountDict[key]}{Path.GetExtension(filename)}";
+                _logger.Warn($"Found more than a single file with the name {filename} in post {crawledUrl.PostId}, file id/sequential number will be appended to its name.");
+
+                string appendStr = _fileCountDict[key].ToString();
+
+                if (crawledUrl.UrlType != CrawledUrlType.ExternalUrl)
+                {
+                    MatchCollection matches = _fileIdRegex.Matches(crawledUrl.Url);
+
+                    if (matches.Count == 0)
+                        throw new DownloadException($"[{crawledUrl.PostId}] Unable to retrieve file id for {crawledUrl.Url}, contact developer!");
+                    if (matches.Count > 1)
+                        throw new DownloadException($"[{crawledUrl.PostId}] More than 1 media found in URL {crawledUrl.Url}");
+
+                    appendStr = matches[0].Groups[5].Value;
+                }
+
+                filename = $"{Path.GetFileNameWithoutExtension(filename)}_{appendStr}{Path.GetExtension(filename)}";
             }
 
             await _webDownloader.DownloadFile(crawledUrl.Url, Path.Combine(downloadDirectory, filename));

--- a/PatreonDownloader.Engine/WebDownloader.cs
+++ b/PatreonDownloader.Engine/WebDownloader.cs
@@ -19,10 +19,12 @@ namespace PatreonDownloader.Engine
         private readonly HttpClient _httpClient;
         private readonly IPuppeteerEngine _puppeteerEngine;
         private readonly Logger _logger = LogManager.GetCurrentClassLogger();
+        private readonly bool _overwriteFiles;
 
-        public WebDownloader(CookieContainer cookieContainer, IPuppeteerEngine puppeteerEngine)
+        public WebDownloader(CookieContainer cookieContainer, IPuppeteerEngine puppeteerEngine, bool overwriteFiles = false)
         {
             _puppeteerEngine = puppeteerEngine ?? throw new ArgumentNullException(nameof(puppeteerEngine));
+            _overwriteFiles = overwriteFiles;
 
             var handler = new HttpClientHandler();
             handler.UseCookies = true;
@@ -45,7 +47,10 @@ namespace PatreonDownloader.Engine
 
             if (File.Exists(path))
             {
-                throw new DownloadException($"File {path} already exists");
+                if(!_overwriteFiles)
+                    throw new DownloadException($"File {path} already exists");
+
+                _logger.Warn($"File {path} already exists, will be overwriten!");
             }
 
             try

--- a/PatreonDownloader.GoogleDriveDownloader/Downloader.cs
+++ b/PatreonDownloader.GoogleDriveDownloader/Downloader.cs
@@ -20,6 +20,10 @@ namespace PatreonDownloader.GoogleDriveDownloader
         private static readonly Logger _logger = LogManager.GetCurrentClassLogger();
         private static readonly GoogleDriveEngine _engine = new GoogleDriveEngine();
 
+        public async Task BeforeStart()
+        {
+            //Not used
+        }
 
         public async Task<bool> IsSupportedUrl(string url)
         {

--- a/PatreonDownloader.TestDownloader/Downloader.cs
+++ b/PatreonDownloader.TestDownloader/Downloader.cs
@@ -9,6 +9,11 @@ namespace PatreonDownloader.TestDownloader
 {
     public sealed class Downloader : IDownloader
     {
+        public async Task BeforeStart()
+        {
+            Console.WriteLine($"Test downloader's BeforeStart called");
+        }
+
         public async Task<bool> IsSupportedUrl(string url)
         {
             Console.WriteLine($"Test downloader's IsSupportedUrl called with url {url}");

--- a/PatreonDownloader.Tests/DirectDownloaderTests.cs
+++ b/PatreonDownloader.Tests/DirectDownloaderTests.cs
@@ -26,28 +26,50 @@ namespace PatreonDownloader.Tests
 
             Mock<IRemoteFilenameRetriever> remoteFilenameRetrieverMock = new Mock<IRemoteFilenameRetriever>(MockBehavior.Strict);
             remoteFilenameRetrieverMock.Setup(x => x.RetrieveRemoteFileName(It.IsAny<string>()))
-                .ReturnsAsync("untitled.jpeg");
+                .ReturnsAsync("1.png");
 
             DirectDownloader directDownloader = new DirectDownloader(webDownloaderMock.Object, remoteFilenameRetrieverMock.Object);
 
+            //Test patreon renaming
             CrawledUrl crawledUrl = new CrawledUrl();
             crawledUrl.PostId = 123456;
-            crawledUrl.Url = "http://test.com/untitled.jpg";
-            crawledUrl.Filename = "untitled.jpeg";
+            crawledUrl.Url = "https://c10.patreonusercontent.com/3/asdaslifdh2321hdsfosdfs%3D/patreon-media/p/post/12345678/4ds697ecx1s475f6er9v2fd4s7sa65h6/1.png?token-time=1234567890&token-hash=pihskdKHrkhsk7223hhdsadsdsadafdslkfherhdiun%3D";
+            crawledUrl.Filename = null;
             crawledUrl.UrlType = CrawledUrlType.PostFile;
 
             await directDownloader.BeforeStart();
             await directDownloader.Download(crawledUrl, "c:\\testpath");
-
             string passedPath1 = moqPathPassed;
+
+            crawledUrl.Url = "https://c10.patreonusercontent.com/3/asdaslifdh2321hdsfosdfs%3D/patreon-media/p/post/12345678/xfsadasdhahd234e325dhsfkshdkfhas/1.png?token-time=1234567890&token-hash=pihskdKHrkhsk7223hhdsadsdsadafdslkfherhdiun%3D";
             await directDownloader.Download(crawledUrl, "c:\\testpath");
             string passedPath2 = moqPathPassed;
+
+            crawledUrl.Url = "https://c10.patreonusercontent.com/3/asdaslifdh2321hdsfosdfs%3D/patreon-media/p/post/12345678/cvvmhjkfghjoitupk23423r54hdsisds/1.png?token-time=1234567890&token-hash=pihskdKHrkhsk7223hhdsadsdsadafdslkfherhdiun%3D";
             await directDownloader.Download(crawledUrl, "c:\\testpath");
             string passedPath3 = moqPathPassed;
 
-            Assert.Equal("c:\\testpath\\123456_post_untitled.jpeg", passedPath1);
-            Assert.Equal("c:\\testpath\\123456_post_untitled_2.jpeg", passedPath2);
-            Assert.Equal("c:\\testpath\\123456_post_untitled_3.jpeg", passedPath3);
+            Assert.Equal("c:\\testpath\\123456_post_1.png", passedPath1);
+            Assert.Equal("c:\\testpath\\123456_post_1_xfsadasdhahd234e325dhsfkshdkfhas.png", passedPath2);
+            Assert.Equal("c:\\testpath\\123456_post_1_cvvmhjkfghjoitupk23423r54hdsisds.png", passedPath3);
+
+            //test external renaming
+            crawledUrl.UrlType = CrawledUrlType.ExternalUrl;
+            crawledUrl.Filename = "untitled.jpeg";
+            crawledUrl.Url = "https://example.com/untitled.jpeg";
+
+            await directDownloader.Download(crawledUrl, "c:\\testpath");
+            string passedPath4 = moqPathPassed;
+
+            await directDownloader.Download(crawledUrl, "c:\\testpath");
+            string passedPath5 = moqPathPassed;
+
+            await directDownloader.Download(crawledUrl, "c:\\testpath");
+            string passedPath6 = moqPathPassed;
+
+            Assert.Equal("c:\\testpath\\123456_external_untitled.jpeg", passedPath4);
+            Assert.Equal("c:\\testpath\\123456_external_untitled_2.jpeg", passedPath5);
+            Assert.Equal("c:\\testpath\\123456_external_untitled_3.jpeg", passedPath6);
         }
     }
 }

--- a/PatreonDownloader.Tests/DirectDownloaderTests.cs
+++ b/PatreonDownloader.Tests/DirectDownloaderTests.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using Moq;
+using PatreonDownloader.Engine;
+using PatreonDownloader.Engine.Helpers;
+using PatreonDownloader.Engine.Stages.Crawling;
+using PatreonDownloader.Engine.Stages.Downloading;
+using PatreonDownloader.Interfaces.Models;
+using PatreonDownloader.Tests.Resources;
+using Xunit;
+
+namespace PatreonDownloader.Tests
+{
+    public class DirectDownloaderTests
+    {
+        [Fact]
+        public async void Download_MultipleFilesWithTheSameName_RenamesFiles()
+        {
+            string moqPathPassed = null;
+            Mock<IWebDownloader> webDownloaderMock = new Mock<IWebDownloader>(MockBehavior.Strict);
+            webDownloaderMock.Setup(x => x.DownloadFile(It.IsAny<string>(), It.IsAny<string>()))
+                .Returns(Task.CompletedTask)
+                .Callback<string, string>((url, path) => { moqPathPassed = path; });
+
+            Mock<IRemoteFilenameRetriever> remoteFilenameRetrieverMock = new Mock<IRemoteFilenameRetriever>(MockBehavior.Strict);
+            remoteFilenameRetrieverMock.Setup(x => x.RetrieveRemoteFileName(It.IsAny<string>()))
+                .ReturnsAsync("untitled.jpeg");
+
+            DirectDownloader directDownloader = new DirectDownloader(webDownloaderMock.Object, remoteFilenameRetrieverMock.Object);
+
+            CrawledUrl crawledUrl = new CrawledUrl();
+            crawledUrl.PostId = 123456;
+            crawledUrl.Url = "http://test.com/untitled.jpg";
+            crawledUrl.Filename = "untitled.jpeg";
+            crawledUrl.UrlType = CrawledUrlType.PostFile;
+
+            await directDownloader.BeforeStart();
+            await directDownloader.Download(crawledUrl, "c:\\testpath");
+
+            string passedPath1 = moqPathPassed;
+            await directDownloader.Download(crawledUrl, "c:\\testpath");
+            string passedPath2 = moqPathPassed;
+            await directDownloader.Download(crawledUrl, "c:\\testpath");
+            string passedPath3 = moqPathPassed;
+
+            Assert.Equal("c:\\testpath\\123456_post_untitled.jpeg", passedPath1);
+            Assert.Equal("c:\\testpath\\123456_post_untitled_2.jpeg", passedPath2);
+            Assert.Equal("c:\\testpath\\123456_post_untitled_3.jpeg", passedPath3);
+        }
+    }
+}


### PR DESCRIPTION
This pull request contains code to solve issue #12.

Every file with duplicate filename will now have either media id or sequential number appended to it (depending on if it is an external or patreon-hosted file)