### PR TITLE
Libraries update, code for issues #21,#22

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 Aleksey Tsutsey & Contributors
+Copyright (c) 2019-2020 Aleksey Tsutsey & Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/PatreonDownloader.App/Models/CommandLineOptions.cs
+++ b/PatreonDownloader.App/Models/CommandLineOptions.cs
@@ -4,8 +4,8 @@ namespace PatreonDownloader.App.Models
 {
     class CommandLineOptions
     {
-        [Option("creator", Required = true, HelpText = "Name of the creator to download from")]
-        public string CreatorName { get; set; }
+        [Option("url", Required = true, HelpText = "Url of the creator's page")]
+        public string Url { get; set; }
         [Option("descriptions", Required = false, HelpText = "Save post descriptions", Default = false)]
         public bool SaveDescriptions { get; set; }
         [Option("embeds", Required = false, HelpText = "Save embedded content metadata", Default = false)]

--- a/PatreonDownloader.App/PatreonDownloader.App.csproj
+++ b/PatreonDownloader.App/PatreonDownloader.App.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommandLineParser" Version="2.6.0" />
-    <PackageReference Include="NLog" Version="4.7.0" />
+    <PackageReference Include="CommandLineParser" Version="2.8.0" />
+    <PackageReference Include="NLog" Version="4.7.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/PatreonDownloader.App/Program.cs
+++ b/PatreonDownloader.App/Program.cs
@@ -31,13 +31,13 @@ namespace PatreonDownloader.App
 
             ParserResult<CommandLineOptions> parserResult = Parser.Default.ParseArguments<CommandLineOptions>(args);
 
-            string creatorName = null;
+            string url = null;
             bool headlessBrowser = true;
 
             PatreonDownloaderSettings settings = null;
             parserResult.WithParsed(options =>
             {
-                creatorName = options.CreatorName;
+                url = options.Url;
                 headlessBrowser = !options.NoHeadless;
                 settings = new PatreonDownloaderSettings
                 {
@@ -51,12 +51,12 @@ namespace PatreonDownloader.App
                 NLogManager.ReconfigureNLog(options.Verbose);
             });
 
-            if (string.IsNullOrEmpty(creatorName) || settings == null)
+            if (string.IsNullOrEmpty(url) || settings == null)
                 return;
 
             try
             {
-                await RunPatreonDownloader(creatorName, headlessBrowser, settings);
+                await RunPatreonDownloader(url, headlessBrowser, settings);
             }
             catch (Exception ex)
             {
@@ -109,7 +109,7 @@ namespace PatreonDownloader.App
             }
         }
 
-        private static async Task RunPatreonDownloader(string creatorName, bool headlessBrowser, PatreonDownloaderSettings settings)
+        private static async Task RunPatreonDownloader(string url, bool headlessBrowser, PatreonDownloaderSettings settings)
         {
             CookieContainer cookieContainer = null;
             using (_cookieRetriever = new PuppeteerEngine.PuppeteerCookieRetriever(headlessBrowser))
@@ -134,7 +134,7 @@ namespace PatreonDownloader.App
                 _patreonDownloader.NewCrawledUrl += PatreonDownloaderOnNewCrawledUrl;
                 _patreonDownloader.CrawlerMessage += PatreonDownloaderOnCrawlerMessage;
                 _patreonDownloader.FileDownloaded += PatreonDownloaderOnFileDownloaded;
-                await _patreonDownloader.Download(creatorName, settings);
+                await _patreonDownloader.Download(url, settings);
             }
         }
 

--- a/PatreonDownloader.App/Properties/AssemblyInfo.cs
+++ b/PatreonDownloader.App/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Patreon Downloader")]
-[assembly: AssemblyCopyright("Copyright 2019 Aleksey Tsutsey & Contributors")]
+[assembly: AssemblyCopyright("Copyright 2019-2020 Aleksey Tsutsey & Contributors")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/PatreonDownloader.Common/Properties/AssemblyInfo.cs
+++ b/PatreonDownloader.Common/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Patreon Downloader")]
-[assembly: AssemblyCopyright("Copyright 2019 Aleksey Tsutsey & Contributors")]
+[assembly: AssemblyCopyright("Copyright 2019-2020 Aleksey Tsutsey & Contributors")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/PatreonDownloader.Engine/IPatreonDownloader.cs
+++ b/PatreonDownloader.Engine/IPatreonDownloader.cs
@@ -12,6 +12,6 @@ namespace PatreonDownloader.Engine
         event EventHandler<NewCrawledUrlEventArgs> NewCrawledUrl;
         event EventHandler<CrawlerMessageEventArgs> CrawlerMessage;
         event EventHandler<FileDownloadedEventArgs> FileDownloaded;
-        Task Download(string creatorName, PatreonDownloaderSettings settings);
+        Task Download(string url, PatreonDownloaderSettings settings);
     }
 }

--- a/PatreonDownloader.Engine/PatreonDownloader.Engine.csproj
+++ b/PatreonDownloader.Engine/PatreonDownloader.Engine.csproj
@@ -9,10 +9,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="HtmlAgilityPack" Version="1.11.16" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.0.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
-    <PackageReference Include="NLog" Version="4.7.0" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.11.25" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.9" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="NLog" Version="4.7.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/PatreonDownloader.Engine/Stages/Crawling/IPageCrawler.cs
+++ b/PatreonDownloader.Engine/Stages/Crawling/IPageCrawler.cs
@@ -13,6 +13,6 @@ namespace PatreonDownloader.Engine.Stages.Crawling
         event EventHandler<PostCrawlEventArgs> PostCrawlEnd;
         event EventHandler<NewCrawledUrlEventArgs> NewCrawledUrl;
         event EventHandler<CrawlerMessageEventArgs> CrawlerMessage;
-        Task<List<CrawledUrl>> Crawl(CampaignInfo campaignInfo, PatreonDownloaderSettings settings);
+        Task<List<CrawledUrl>> Crawl(CampaignInfo campaignInfo, PatreonDownloaderSettings settings, string downloadDirectory);
     }
 }

--- a/PatreonDownloader.Engine/Stages/Crawling/PageCrawler.cs
+++ b/PatreonDownloader.Engine/Stages/Crawling/PageCrawler.cs
@@ -31,7 +31,8 @@ namespace PatreonDownloader.Engine.Stages.Crawling
             _webDownloader = webDownloader ?? throw new ArgumentNullException(nameof(webDownloader));
         }
 
-        public async Task<List<CrawledUrl>> Crawl(CampaignInfo campaignInfo, PatreonDownloaderSettings settings)
+        public async Task<List<CrawledUrl>> Crawl(CampaignInfo campaignInfo, PatreonDownloaderSettings settings,
+            string downloadDirectory)
         {
             if(campaignInfo.Id < 1)
                 throw new ArgumentException("Campaign ID cannot be less than 1");
@@ -43,6 +44,8 @@ namespace PatreonDownloader.Engine.Stages.Crawling
                 throw new ArgumentException("Campaign name cannot be null or empty");
             if (settings == null)
                 throw new ArgumentNullException(nameof(settings));
+            if(string.IsNullOrWhiteSpace(downloadDirectory))
+                throw new ArgumentException("Download directory cannot be empty");
 
             _logger.Debug($"Starting crawling campaign {campaignInfo.Name}");
             List<CrawledUrl> crawledUrls = new List<CrawledUrl>();
@@ -56,7 +59,7 @@ namespace PatreonDownloader.Engine.Stages.Crawling
             }
 
             //TODO: Research possibility of not hardcoding this string
-            string nextPage = $"https://www.patreon.com/api/posts?include=user%2Cattachments%2Cuser_defined_tags%2Ccampaign%2Cpoll.choices%2Cpoll.current_user_responses.user%2Cpoll.current_user_responses.choice%2Cpoll.current_user_responses.poll%2Caccess_rules.tier.null%2Cimages.null%2Caudio.null&fields[post]=change_visibility_at%2Ccomment_count%2Ccontent%2Ccurrent_user_can_delete%2Ccurrent_user_can_view%2Ccurrent_user_has_liked%2Cembed%2Cimage%2Cis_paid%2Clike_count%2Cmin_cents_pledged_to_view%2Cpost_file%2Cpost_metadata%2Cpublished_at%2Cpatron_count%2Cpatreon_url%2Cpost_type%2Cpledge_url%2Cthumbnail_url%2Cteaser_text%2Ctitle%2Cupgrade_url%2Curl%2Cwas_posted_by_campaign_owner&fields[user]=image_url%2Cfull_name%2Curl&fields[campaign]=show_audio_post_download_links%2Cavatar_photo_url%2Cearnings_visibility%2Cis_nsfw%2Cis_monthly%2Cname%2Curl&fields[access_rule]=access_rule_type%2Camount_cents&fields[media]=id%2Cimage_urls%2Cdownload_url%2Cmetadata%2Cfile_name&fields[post]=change_visibility_at%2Ccomment_count%2Ccontent%2Ccurrent_user_can_delete%2Ccurrent_user_can_view%2Ccurrent_user_has_liked%2Cembed%2Cimage%2Cis_paid%2Clike_count%2Cmin_cents_pledged_to_view%2Cpost_file%2Cpost_metadata%2Cpublished_at%2Cpatron_count%2Cpatreon_url%2Cpost_type%2Cpledge_url%2Cthumbnail_url%2Cteaser_text%2Ctitle%2Cupgrade_url%2Curl%2Cwas_posted_by_campaign_owner&fields[user]=image_url%2Cfull_name%2Curl&fields[campaign]=show_audio_post_download_links%2Cavatar_photo_url%2Cearnings_visibility%2Cis_nsfw%2Cis_monthly%2Cname%2Curl&fields[access_rule]=access_rule_type%2Camount_cents&fields[media]=id%2Cimage_urls%2Cdownload_url%2Cmetadata%2Cfile_name&sort=-published_at&filter[campaign_id]={campaignInfo.Id}&filter[is_draft]=false&filter[contains_exclusive_posts]=true&json-api-use-default-includes=false&json-api-version=1.0";
+            string nextPage = $"https://www.patreon.com/api/posts?include=user%2Cattachments%2Ccampaign%2Cpoll.choices%2Cpoll.current_user_responses.user%2Cpoll.current_user_responses.choice%2Cpoll.current_user_responses.poll%2Caccess_rules.tier.null%2Cimages.null%2Caudio.null&fields[post]=change_visibility_at%2Ccomment_count%2Ccontent%2Ccurrent_user_can_delete%2Ccurrent_user_can_view%2Ccurrent_user_has_liked%2Cembed%2Cimage%2Cis_paid%2Clike_count%2Cmin_cents_pledged_to_view%2Cpost_file%2Cpost_metadata%2Cpublished_at%2Cpatron_count%2Cpatreon_url%2Cpost_type%2Cpledge_url%2Cthumbnail_url%2Cteaser_text%2Ctitle%2Cupgrade_url%2Curl%2Cwas_posted_by_campaign_owner&fields[user]=image_url%2Cfull_name%2Curl&fields[campaign]=show_audio_post_download_links%2Cavatar_photo_url%2Cearnings_visibility%2Cis_nsfw%2Cis_monthly%2Cname%2Curl&fields[access_rule]=access_rule_type%2Camount_cents&fields[media]=id%2Cimage_urls%2Cdownload_url%2Cmetadata%2Cfile_name&fields[post]=change_visibility_at%2Ccomment_count%2Ccontent%2Ccurrent_user_can_delete%2Ccurrent_user_can_view%2Ccurrent_user_has_liked%2Cembed%2Cimage%2Cis_paid%2Clike_count%2Cmin_cents_pledged_to_view%2Cpost_file%2Cpost_metadata%2Cpublished_at%2Cpatron_count%2Cpatreon_url%2Cpost_type%2Cpledge_url%2Cthumbnail_url%2Cteaser_text%2Ctitle%2Cupgrade_url%2Curl%2Cwas_posted_by_campaign_owner&fields[user]=image_url%2Cfull_name%2Curl&fields[campaign]=show_audio_post_download_links%2Cavatar_photo_url%2Cearnings_visibility%2Cis_nsfw%2Cis_monthly%2Cname%2Curl&fields[access_rule]=access_rule_type%2Camount_cents&fields[media]=id%2Cimage_urls%2Cdownload_url%2Cmetadata%2Cfile_name&sort=-published_at&filter[campaign_id]={campaignInfo.Id}&filter[is_draft]=false&filter[contains_exclusive_posts]=true&json-api-use-default-includes=false&json-api-version=1.0";
 
             int page = 0;
             while (!string.IsNullOrEmpty(nextPage))
@@ -66,10 +69,10 @@ namespace PatreonDownloader.Engine.Stages.Crawling
                 string json = await _webDownloader.DownloadString(nextPage);
 
                 if(settings.SaveJson)
-                    await File.WriteAllTextAsync(Path.Combine(settings.DownloadDirectory, $"page_{page}.json"),
+                    await File.WriteAllTextAsync(Path.Combine(downloadDirectory, $"page_{page}.json"),
                         json);
 
-                ParsingResult result = await ParsePage(json, settings);
+                ParsingResult result = await ParsePage(json, settings.SaveDescriptions, settings.SaveEmbeds, downloadDirectory);
 
                 if(result.Entries.Count > 0)
                     crawledUrls.AddRange(result.Entries);
@@ -84,7 +87,7 @@ namespace PatreonDownloader.Engine.Stages.Crawling
             return crawledUrls;
         }
 
-        private async Task<ParsingResult> ParsePage(string json, PatreonDownloaderSettings settings)
+        private async Task<ParsingResult> ParsePage(string json, bool saveDescriptions, bool saveEmbeds, string downloadDirectory)
         {
             List<CrawledUrl> galleryEntries = new List<CrawledUrl>();
             List<string> skippedIncludesList = new List<string>(); //List for all included data which current account doesn't have access to
@@ -122,11 +125,11 @@ namespace PatreonDownloader.Engine.Stages.Crawling
                     continue;
                 }
 
-                if (settings.SaveDescriptions)
+                if (saveDescriptions)
                 {
                     try
                     {
-                        await File.WriteAllTextAsync(Path.Combine(settings.DownloadDirectory, $"{jsonEntry.Id}_description.txt"),
+                        await File.WriteAllTextAsync(Path.Combine(downloadDirectory, $"{jsonEntry.Id}_description.txt"),
                             jsonEntry.Attributes.Content); //TODO: WRITE TITLE, AND OTHER METADATA?
                     }
                     catch (Exception ex)
@@ -144,13 +147,13 @@ namespace PatreonDownloader.Engine.Stages.Crawling
 
                 if (jsonEntry.Attributes.Embed != null)
                 {
-                    if (settings.SaveEmbeds)
+                    if (saveEmbeds)
                     {
                         _logger.Debug($"[{jsonEntry.Id}] Embed found, metadata will be saved");
                         try
                         {
                             await File.WriteAllTextAsync(
-                                Path.Combine(settings.DownloadDirectory, $"{jsonEntry.Id}_embed.txt"),
+                                Path.Combine(downloadDirectory, $"{jsonEntry.Id}_embed.txt"),
                                 jsonEntry.Attributes.Embed.ToString());
                         }
                         catch (Exception ex)

--- a/PatreonDownloader.GoogleDriveDownloader/PatreonDownloader.GoogleDriveDownloader.csproj
+++ b/PatreonDownloader.GoogleDriveDownloader/PatreonDownloader.GoogleDriveDownloader.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Apis.Drive.v3" Version="1.45.0.1895" />
-    <PackageReference Include="NLog" Version="4.7.0" />
+    <PackageReference Include="Google.Apis.Drive.v3" Version="1.49.0.2117" />
+    <PackageReference Include="NLog" Version="4.7.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/PatreonDownloader.GoogleDriveDownloader/PatreonDownloader.GoogleDriveDownloader.csproj
+++ b/PatreonDownloader.GoogleDriveDownloader/PatreonDownloader.GoogleDriveDownloader.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 
   <ItemGroup>
@@ -12,10 +13,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\PatreonDownloader.Common\PatreonDownloader.Common.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Folder Include="Properties\" />
   </ItemGroup>
 
 </Project>

--- a/PatreonDownloader.GoogleDriveDownloader/Properties/AssemblyInfo.cs
+++ b/PatreonDownloader.GoogleDriveDownloader/Properties/AssemblyInfo.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("Patreon Downloader Engine Library")]
+[assembly: AssemblyTitle("Patreon Downloader Google Drive Plugin")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
@@ -20,7 +20,7 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("733001b2-a3ad-4e99-b657-c7edf7e64427")]
+[assembly: Guid("0f883da3-d59b-4f79-a380-07f8a13eadcd")]
 
 // Version information for an assembly consists of the following four values:
 //
@@ -31,7 +31,3 @@ using System.Runtime.InteropServices;
 //
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
-
-//Alow tests to see internal classes
-[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]
-[assembly: InternalsVisibleTo("PatreonDownloader.Tests")]

--- a/PatreonDownloader.PuppeteerEngine/PatreonDownloader.PuppeteerEngine.csproj
+++ b/PatreonDownloader.PuppeteerEngine/PatreonDownloader.PuppeteerEngine.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NLog" Version="4.7.0" />
-    <PackageReference Include="PuppeteerSharp" Version="1.20.0" />
+    <PackageReference Include="NLog" Version="4.7.5" />
+    <PackageReference Include="PuppeteerSharp" Version="2.0.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/PatreonDownloader.PuppeteerEngine/Properties/AssemblyInfo.cs
+++ b/PatreonDownloader.PuppeteerEngine/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Patreon Downloader")]
-[assembly: AssemblyCopyright("Copyright 2019 Aleksey Tsutsey & Contributors")]
+[assembly: AssemblyCopyright("Copyright 2019-2020 Aleksey Tsutsey & Contributors")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/PatreonDownloader.Tests/CampaignIdRetrieverTests.cs
+++ b/PatreonDownloader.Tests/CampaignIdRetrieverTests.cs
@@ -56,13 +56,13 @@ namespace PatreonDownloader.Tests
         }
 
         [Fact]
-        public async void RetrieveCampaignId_UrlIsNull_ThrowsArgumentNullException()
+        public async void RetrieveCampaignId_UrlIsNull_ThrowsArgumentException()
         {
             Mock<IWebDownloader> webDownloaderMock = new Mock<IWebDownloader>(MockBehavior.Strict);
 
             CampaignIdRetriever campaignIdRetriever = new CampaignIdRetriever(webDownloaderMock.Object);
 
-            await Assert.ThrowsAsync<ArgumentNullException>(async () => await campaignIdRetriever.RetrieveCampaignId(null));
+            await Assert.ThrowsAsync<ArgumentException>(async () => await campaignIdRetriever.RetrieveCampaignId(null));
         }
     }
 }

--- a/PatreonDownloader.Tests/PatreonDownloader.Tests.csproj
+++ b/PatreonDownloader.Tests/PatreonDownloader.Tests.csproj
@@ -17,10 +17,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
-    <PackageReference Include="Moq" Version="4.13.0" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="Moq" Version="4.14.7" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@ IMPORTANT: You need a valid patreon account to download both free and paid conte
 
 ## Usage
 #### Download all available files from creator
-PatreonDownloader.exe --creator #creatorname#. Creator name can be obtained by looking at their page url: https://www.patreon.com/#creator_name_here#/posts
+PatreonDownloader.App.exe --creator #creatorname#. Creator name can be obtained by looking at their page url: https://www.patreon.com/#creator_name_here#/posts
 #### Download all available files from creator into custom directory and save all possible data (post contents, embed metadata, cover and avatar, json responses)
-PatreonDownloader.exe --creator #creatorname# --download-directory c:\downloads --descriptions --embeds --campaign-images --json
+PatreonDownloader.App.exe --creator #creatorname# --download-directory c:\downloads --descriptions --embeds --campaign-images --json
 #### Show available commands and their descriptions
-PatreonDownloader.exe --help
+PatreonDownloader.App.exe --help
 
 ## Build instructions
 See docs\BUILDING.md

--- a/README.md
+++ b/README.md
@@ -5,9 +5,13 @@ IMPORTANT: You need a valid patreon account to download both free and paid conte
 
 ## Usage
 #### Download all available files from creator
-PatreonDownloader.App.exe --creator #creatorname#. Creator name can be obtained by looking at their page url: https://www.patreon.com/#creator_name_here#/posts
+PatreonDownloader.App.exe --url #page url#. Page url should follow one of the following patterns:
+* https://www.patreon.com/m/#numbers#/posts
+* https://www.patreon.com/user?u=#numbers#
+* https://www.patreon.com/user/posts?u=#numbers#
+* https://www.patreon.com/#creator name#/posts
 #### Download all available files from creator into custom directory and save all possible data (post contents, embed metadata, cover and avatar, json responses)
-PatreonDownloader.App.exe --creator #creatorname# --download-directory c:\downloads --descriptions --embeds --campaign-images --json
+PatreonDownloader.App.exe --url #page url# --download-directory c:\downloads --descriptions --embeds --campaign-images --json
 #### Show available commands and their descriptions
 PatreonDownloader.App.exe --help
 


### PR DESCRIPTION
In this pull request:
* Updated libraries to more recent versions
* Updated copyright year
* Added assemblyinfo for google drive plugin
* Updated readme
* Replaced creator name command line parameter with url parameter. This allows app to support creators without "friendly" name.
* Name of the download directory is now retrieved from campaign info if it was not provided using --download-directory command line parameter.
* Removed user_defined_tags from api request. Should improve crawl performance on creators who go overboard with post tagging.