### PR TITLE
Fix for #55: cloudflare no longer uses __cfduid cookie

### DIFF
--- a/PatreonDownloader.Engine/Stages/Initialization/CookieValidator.cs
+++ b/PatreonDownloader.Engine/Stages/Initialization/CookieValidator.cs
@@ -29,8 +29,6 @@ namespace PatreonDownloader.Engine.Stages.Initialization
 
             if (cookies["__cf_bm"] == null)
                 throw new CookieValidationException("__cf_bm cookie not found");
-            if (cookies["__cfduid"] == null)
-                throw new CookieValidationException("__cfduid cookie not found");
             if (cookies["session_id"] == null)
                 throw new CookieValidationException("session_id cookie not found");
             if (cookies["patreon_device_id"] == null)


### PR DESCRIPTION
[Starting with may 10th __cfduid cookie is no longer used by cloudflare](https://blog.cloudflare.com/deprecating-cfduid-cookie/). This hotfix removes check for this cookie's presence.