### PR TITLE
Add download directory pattern support

### DIFF
--- a/PatreonDownloader.App/Models/CommandLineOptions.cs
+++ b/PatreonDownloader.App/Models/CommandLineOptions.cs
@@ -31,5 +31,8 @@ namespace PatreonDownloader.App.Models
 
         [Option("remote-browser-address", Required = false, HelpText = "Advanced users only. Address of the browser with remote debugging enabled. Refer to documentation for more details.")]
         public string RemoteBrowserAddress { get; set; }
+
+        [Option("directory-pattern", Required = false, HelpText = "Choice a pattern for the final download directory.")]
+        public DirectoryPatternType DirectoryPattern { get; set; }
     }
 }

--- a/PatreonDownloader.App/Program.cs
+++ b/PatreonDownloader.App/Program.cs
@@ -192,7 +192,8 @@ namespace PatreonDownloader.App
                 SaveEmbeds = commandLineOptions.SaveEmbeds,
                 SaveJson = commandLineOptions.SaveJson,
                 DownloadDirectory = commandLineOptions.DownloadDirectory,
-                RemoteFileSizeNotAvailableAction = commandLineOptions.NoRemoteSizeAction
+                RemoteFileSizeNotAvailableAction = commandLineOptions.NoRemoteSizeAction,
+                DirectoryPattern = commandLineOptions.DirectoryPattern
             };
 
             return settings;

--- a/PatreonDownloader.Implementation/Models/PatreonDownloaderSettings.cs
+++ b/PatreonDownloader.Implementation/Models/PatreonDownloaderSettings.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using UniversalDownloaderPlatform.Common.Enums;
 using UniversalDownloaderPlatform.Common.Helpers;
 using UniversalDownloaderPlatform.Common.Interfaces.Models;
 using UniversalDownloaderPlatform.DefaultImplementations.Models;
@@ -14,6 +15,7 @@ namespace PatreonDownloader.Implementation.Models
         private bool _saveJson;
         private bool _saveAvatarAndCover;
         private string _downloadDirectory;
+        private DirectoryPatternType _directoryPattern = DirectoryPatternType.Default;
 
         public bool SaveDescriptions
         {
@@ -46,6 +48,12 @@ namespace PatreonDownloader.Implementation.Models
         {
             get => _downloadDirectory;
             set => ConsumableSetter.Set(Consumed, ref _downloadDirectory, value);
+        }
+
+        public DirectoryPatternType DirectoryPattern
+        {
+            get => _directoryPattern;
+            set => ConsumableSetter.Set(Consumed, ref _directoryPattern, value);
         }
 
         public PatreonDownloaderSettings()

--- a/PatreonDownloader.Implementation/PatreonCrawledUrl.cs
+++ b/PatreonDownloader.Implementation/PatreonCrawledUrl.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using PatreonDownloader.Implementation.Enums;
-using UniversalDownloaderPlatform.Common.Interfaces.Models;
 using UniversalDownloaderPlatform.DefaultImplementations.Models;
 
 namespace PatreonDownloader.Implementation
@@ -8,6 +7,8 @@ namespace PatreonDownloader.Implementation
     public class PatreonCrawledUrl : CrawledUrl
     {
         public string PostId { get; set; }
+        public string Title { get; set; }
+        public DateTime PublishAt { get; set; }
         public PatreonCrawledUrlType UrlType { get; set; }
 
         public string UrlTypeAsFriendlyString
@@ -38,7 +39,7 @@ namespace PatreonDownloader.Implementation
 
         public object Clone()
         {
-            return new PatreonCrawledUrl { PostId = PostId, Url = Url, Filename = Filename, UrlType = UrlType };
+            return new PatreonCrawledUrl { PostId = PostId, Url = Url, Filename = Filename, UrlType = UrlType, Title = Title, PublishAt = PublishAt };
         }
     }
 }

--- a/PatreonDownloader.Implementation/PatreonDirectoryPatternFormat.cs
+++ b/PatreonDownloader.Implementation/PatreonDirectoryPatternFormat.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using UniversalDownloaderPlatform.Common.Enums;
+using UniversalDownloaderPlatform.Common.Helpers;
+
+namespace PatreonDownloader.Implementation
+{
+    internal class PatreonDirectoryPatternFormat
+    {
+        public static string Format(string basePath, DirectoryPatternType directoryPattern, DateTime publishAt, string title)
+        {
+            if (directoryPattern != DirectoryPatternType.Default)
+            {
+                string pusblishAt = publishAt.ToString("yyyy-MM-dd");
+
+                if (!String.IsNullOrEmpty(title))
+                {
+                    var tempDir = new StringBuilder(title);
+
+                    foreach (char invalidChar in UniversalDirectoryPatternFormat.InvalidPathChars)
+                        tempDir.Replace(invalidChar.ToString(), String.Empty);
+
+                    title = tempDir.ToString().Trim();
+
+                    while (title.Length > 1 && title[^1] == '.')
+                        title = title.Remove(title.Length - 1).Trim();
+                }
+
+                if (directoryPattern == DirectoryPatternType.PostTitle)
+                    return Path.Combine(basePath, title);
+
+                if (directoryPattern == DirectoryPatternType.PublishedAt)
+                    return Path.Combine(basePath, pusblishAt);
+                else if (directoryPattern == DirectoryPatternType.PublishedAtAndPostTitle)
+                    return Path.Combine(basePath, (pusblishAt + " " + title).Trim());
+
+                throw new NotSupportedException(directoryPattern.ToString());
+            }
+
+            return String.Empty;
+        }
+    }
+}

--- a/PatreonDownloader.PuppeteerEngine/Wrappers/Browser/WebPage.cs
+++ b/PatreonDownloader.PuppeteerEngine/Wrappers/Browser/WebPage.cs
@@ -27,6 +27,10 @@ namespace PatreonDownloader.PuppeteerEngine.Wrappers.Browser
         public async Task<IWebResponse> GoToAsync(string url, int? timeout = null, WaitUntilNavigation[] waitUntil = null)
         {
             await ConfigurePage();
+
+            if (!timeout.HasValue)
+                timeout = 60000;
+
             Response response = await _page.GoToAsync(url, timeout, waitUntil);
             IWebResponse webResponse = new WebResponse(response);
             return webResponse;


### PR DESCRIPTION
I add support for custom directory pattern. I download a lot of battlemap for Virtual Tabletop and I prefer create a folder by Patreon Post. It's more easy to explore.
![2021_10_01_12_47_42_DynamicDungeons_Test](https://user-images.githubusercontent.com/4063032/135657886-0c880bcc-4581-472b-9e54-2f2850c70048.png)