### PR TITLE
Fix file sequence number count

### DIFF
--- a/PatreonDownloader.Implementation/PatreonCrawledUrlProcessor.cs
+++ b/PatreonDownloader.Implementation/PatreonCrawledUrlProcessor.cs
@@ -146,14 +146,19 @@ namespace PatreonDownloader.Implementation
                 }
 
                 string key = $"{crawledUrl.PostId}_{filename.ToLowerInvariant()}";
+                int fileCount = 1;
 
-                _fileCountDict.AddOrUpdate(key, 0, (key, oldValue) => oldValue + 1);
+                _fileCountDict.AddOrUpdate(key, 1, (key, oldValue) =>
+                {
+                    fileCount = oldValue + 1;
+                    return oldValue + 1;
+                });
 
-                if (_fileCountDict[key] > 1)
+                if (fileCount > 1)
                 {
                     _logger.Warn($"Found more than a single file with the name {filename} in the same folder in post {crawledUrl.PostId}, sequential number will be appended to its name.");
 
-                    string appendStr = _fileCountDict[key].ToString();
+                    string appendStr = fileCount.ToString();
 
                     if (crawledUrl.UrlType != PatreonCrawledUrlType.ExternalUrl)
                     {


### PR DESCRIPTION
Fix #163 

The downloader overwrites the first two files that share the same name accidentally, and that may cause `being used by another process` exception and data loss.

This commit uses another method to read sequence number of the file, which may reduce the probability of resource competition (read wrong sequence number with multi-thread).