### PR TITLE
Rename Patreon files capture by reading html

### DIFF
--- a/PatreonDownloader.Implementation/PatreonCrawledUrlProcessor.cs
+++ b/PatreonDownloader.Implementation/PatreonCrawledUrlProcessor.cs
@@ -155,15 +155,20 @@ namespace PatreonDownloader.Implementation
 
                     string appendStr = _fileCountDict[key].ToString();
 
+                    // External files captured by plugin may also Patreon files 
+                    MatchCollection matches = _fileIdRegex.Matches(crawledUrl.Url);
+
                     if (crawledUrl.UrlType != PatreonCrawledUrlType.ExternalUrl)
                     {
-                        MatchCollection matches = _fileIdRegex.Matches(crawledUrl.Url);
-
                         if (matches.Count == 0)
                             throw new DownloadException($"[{crawledUrl.PostId}] Unable to retrieve file id for {crawledUrl.Url}, contact developer!");
                         if (matches.Count > 1)
                             throw new DownloadException($"[{crawledUrl.PostId}] More than 1 media found in URL {crawledUrl.Url}");
+                    }
 
+                    // If we get file id successfully
+                    if (matches.Count == 1)
+                    {
                         appendStr = matches[0].Groups[4].Value;
                     }
 


### PR DESCRIPTION
This may mitigate #181 by adding file id to filename instead of adding sequence number at the end of file.

But this change may cause the file order to be lost, which could be a workaround before we find a way to generate a stable file sequence number.