### PR TITLE
Space in regex causing failure

### DIFF
--- a/PatreonDownloader.Implementation/PatreonCrawlTargetInfoRetriever.cs
+++ b/PatreonDownloader.Implementation/PatreonCrawlTargetInfoRetriever.cs
@@ -35,7 +35,7 @@ namespace PatreonDownloader.Implementation
             {
                 string pageHtml = await _webDownloader.DownloadString(url);
 
-                Regex regex = new Regex("\"self\": \"https:\\/\\/www\\.patreon\\.com\\/api\\/campaigns\\/(\\d+)\"");
+                Regex regex = new Regex("\"self\":\"https:\\/\\/www\\.patreon\\.com\\/api\\/campaigns\\/(\\d+)\"");
                 Match match = regex.Match(pageHtml);
                 if (!match.Success)
                 {

--- a/PatreonDownloader.Implementation/PatreonCrawlTargetInfoRetriever.cs
+++ b/PatreonDownloader.Implementation/PatreonCrawlTargetInfoRetriever.cs
@@ -35,7 +35,7 @@ namespace PatreonDownloader.Implementation
             {
                 string pageHtml = await _webDownloader.DownloadString(url);
 
-                Regex regex = new Regex("\"self\":\"https:\\/\\/www\\.patreon\\.com\\/api\\/campaigns\\/(\\d+)\"");
+                Regex regex = new Regex("\"self\": ?\"https:\\/\\/www\\.patreon\\.com\\/api\\/campaigns\\/(\\d+)\"");
                 Match match = regex.Match(pageHtml);
                 if (!match.Success)
                 {


### PR DESCRIPTION
https://github.com/AlexCSDev/PatreonDownloader/issues/196

Addresses this issue. The space in that regex fails to find the campaign text. Not sure if that space changed or needs to be made optional.