### PR TITLE
Fix cookie validation error

### DIFF
--- a/PatreonDownloader.Implementation/PatreonCookieValidator.cs
+++ b/PatreonDownloader.Implementation/PatreonCookieValidator.cs
@@ -26,7 +26,7 @@ namespace PatreonDownloader.Implementation
             if (cookieContainer == null)
                 throw new ArgumentNullException(nameof(cookieContainer));
 
-            CookieCollection cookies = cookieContainer.GetCookies(new Uri("https://patreon.com"));
+            CookieCollection cookies = cookieContainer.GetAllCookies();
 
             if (cookies["__cf_bm"] == null)
                 throw new CookieValidationException("__cf_bm cookie not found");


### PR DESCRIPTION
Closes #259 by changing cookie validation to check all cookies, instead of only cookies from `https://patreon.com/`. This should be future-proof as well, in the event that Patreon further changes their cookies to use other domains.

This PR is intended to provide an easy, low-effort way to implement a fix for Patreon's recent breaking change, and will be closed should the issue be otherwise resolved.