### PR TITLE
Allow to retrieve campaign id from 'cw' creators too

### DIFF
--- a/PatreonDownloader.Implementation/PatreonCrawlTargetInfoRetriever.cs
+++ b/PatreonDownloader.Implementation/PatreonCrawlTargetInfoRetriever.cs
@@ -39,7 +39,7 @@ namespace PatreonDownloader.Implementation
             {
                 string pageHtml = await _webDownloader.DownloadString(url);
 
-                Regex regex = new Regex("\"self\": ?\"https:\\/\\/www\\.patreon\\.com\\/api\\/campaigns\\/(\\d+)\"");
+                Regex regex = new Regex("\\\\?\"self\\\\?\": ?\\\\?\"https:\\/\\/www\\.patreon\\.com\\/api\\/campaigns\\/(\\d+)\\\\?\"");
                 Match match = regex.Match(pageHtml);
                 if (!match.Success)
                     throw new UniversalDownloaderException($"Unable to retrieve campaign id: regex failed. Report this error to developer.");


### PR DESCRIPTION
Patreon seems apply change on some creator. Most creators, at least for me, have url like that : `https://www.patreon.com/<CreatorName>` but some creators have url like that : `https://www.patreon.com/cw/<CreatorName>` an example is [sinlaire](https://www.patreon.com/cw/sinlaire).

For these creators, the website have changed and the campaign id is formatted like that :
```html
{\"self\":\"https://www.patreon.com/api/campaigns/<campaignId>\"}
```

So to avoid breaking anything but allow downloading content of theses creator, i submit this PR with update regex for campaignId retrieval to support quote escaping