### PR TITLE
Add option to disable downloading files (--no-files)

### DIFF
--- a/PatreonDownloader.App/Models/CommandLineOptions.cs
+++ b/PatreonDownloader.App/Models/CommandLineOptions.cs
@@ -8,6 +8,10 @@ namespace PatreonDownloader.App.Models
     {
         [Option("url", Required = true, HelpText = "Url of the creator's page")]
         public string Url { get; set; }
+
+        [Option("no-files", Required = false, HelpText = "Do not download files (images, attachments, media, etc.). Useful when only post metadata like descriptions is needed.", Default = false)]
+        public bool NoFiles { get; set; }
+
         [Option("descriptions", Required = false, HelpText = "Save post descriptions", Default = false)]
         public bool SaveDescriptions { get; set; }
         [Option("embeds", Required = false, HelpText = "Save embedded content metadata", Default = false)]

--- a/PatreonDownloader.App/Program.cs
+++ b/PatreonDownloader.App/Program.cs
@@ -153,6 +153,7 @@ namespace PatreonDownloader.App
                 UrlBlackList = (_configuration["UrlBlackList"] ?? "").ToLowerInvariant().Split("|").ToList(),
                 UserAgent = "Patreon/126.9.0.15 (Android; Android 14; Scale/2.10)",
                 CookieContainer = null,
+                NoFiles = commandLineOptions.NoFiles,
                 SaveAvatarAndCover = commandLineOptions.SaveAvatarAndCover,
                 SaveDescriptions = commandLineOptions.SaveDescriptions,
                 SaveEmbeds = commandLineOptions.SaveEmbeds,

--- a/PatreonDownloader.Implementation/Models/PatreonDownloaderSettings.cs
+++ b/PatreonDownloader.Implementation/Models/PatreonDownloaderSettings.cs
@@ -20,6 +20,11 @@ namespace PatreonDownloader.Implementation.Models
         public bool SaveAvatarAndCover { get; init; }
 
         /// <summary>
+        /// If true, do not download remote files (images, attachments, media, etc.)
+        /// </summary>
+        public bool NoFiles { get; init; }
+
+        /// <summary>
         /// Create a new directory for every post and store files of said post in that directory
         /// </summary>
         public bool IsUseSubDirectories { get; init; }

--- a/PatreonDownloader.Implementation/PatreonPageCrawler.cs
+++ b/PatreonDownloader.Implementation/PatreonPageCrawler.cs
@@ -87,7 +87,7 @@ namespace PatreonDownloader.Implementation
 
                 ParsingResult result = await ParsePage(json);
 
-                if(result.CrawledUrls.Count > 0)
+                if(!_patreonDownloaderSettings.NoFiles && result.CrawledUrls.Count > 0)
                     crawledUrls.AddRange(result.CrawledUrls);
 
                 nextPage = result.NextPage;


### PR DESCRIPTION
Add a command line option called `--no-files`. When this option is enabled, the files (including images, attachments, media, etc.) are not downloaded. The intended usage is when the user specifies `--descriptions`, he may be only interested in the descriptions, not the images.